### PR TITLE
Update NS records on new zone creation

### DIFF
--- a/octodns_ns1/__init__.py
+++ b/octodns_ns1/__init__.py
@@ -15,7 +15,7 @@ from pycountry_convert import country_alpha2_to_continent_code
 
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
-from octodns.record import Record, Update
+from octodns.record import Create, NsRecord, Record, Update
 from octodns.record.geo_data import geo_data
 
 __VERSION__ = '0.0.5'
@@ -1747,6 +1747,21 @@ class Ns1Provider(BaseProvider):
 
         return extra
 
+    def _force_root_ns_update(self, changes):
+        '''
+        Changes any 'Create' changetype for a root NS record to an 'Update'
+        changetype. Used on new zone creation, since NS1 will automatically create root NS records (see https://ns1.com/api?docId=2184).
+        This means our desired NS records must be applied as an Update, rather than a Create.
+        '''
+        for change in changes:
+            if (
+                change.record.name == ""
+                and isinstance(change.record, NsRecord)
+                and isinstance(change, Create)
+            ):
+                change.__class__ = Update
+                return
+
     def _apply_Create(self, ns1_zone, change):
         new = change.new
         zone = new.zone.name[:-1]
@@ -1763,9 +1778,12 @@ class Ns1Provider(BaseProvider):
         _type = new._type
         params, active_monitor_ids = getattr(self, f'_params_for_{_type}')(new)
         self._client.records_update(zone, domain, _type, **params)
-        # If we're cleaning up we need to send in the old record since it'd
-        # have anything that needs cleaning up
-        self._monitors_gc(change.existing, active_monitor_ids)
+        # It's possible change.existing is None because in the case of zone creation, we swap out the NS record Create for an Update, but we don't set the existing
+        # record (see _force_root_ns_update).
+        if change.existing is not None:
+            # If we're cleaning up we need to send in the old record since it'd
+            # have anything that needs cleaning up
+            self._monitors_gc(change.existing, active_monitor_ids)
 
     def _apply_Delete(self, ns1_zone, change):
         existing = change.existing
@@ -1803,6 +1821,7 @@ class Ns1Provider(BaseProvider):
                 raise
             self.log.debug('_apply:   no matching zone, creating')
             ns1_zone = self._client.zones_create(domain_name)
+            self._force_root_ns_update(changes)
 
         for change in changes:
             class_name = change.__class__.__name__

--- a/tests/test_provider_ns1.py
+++ b/tests/test_provider_ns1.py
@@ -543,15 +543,6 @@ class TestNs1Provider(TestCase):
                 ),
                 call(
                     'unit.tests',
-                    'unit.tests',
-                    'NS',
-                    answers=['ns1.unit.tests.', 'ns2.unit.tests.'],
-                    filters=[],
-                    regions={},
-                    ttl=37,
-                ),
-                call(
-                    'unit.tests',
                     '1.2.3.4.unit.tests',
                     'PTR',
                     answers=['one.one.one.one.', 'two.two.two.two.'],
@@ -559,6 +550,20 @@ class TestNs1Provider(TestCase):
                 ),
             ],
             any_order=True,
+        )
+        # New zone was created, so we should update NS records instead of creating
+        record_update_mock.assert_has_calls(
+            [
+                call(
+                    'unit.tests',
+                    'unit.tests',
+                    'NS',
+                    answers=['ns1.unit.tests.', 'ns2.unit.tests.'],
+                    filters=[],
+                    regions={},
+                    ttl=37,
+                )
+            ]
         )
 
         # Update & delete


### PR DESCRIPTION
## Overview
Adds logic to apply root NS changes as updates if we're creating a new zone. We need this because NS1 implicitly creates root NS records when we create a new zone, so we'll get errors creating a new zone that includes root NS configuration, since we're trying to _create_ the records instead of _updating_ them. This is adapted from https://github.com/octodns/octodns/commit/259fc59fa0b2ec70043389c3e0164139d63b9495.

This fix is a bit hacky, but I wanna unblock ourselves before investigating a proper fix that we can submit upstream. I also pushed this down into this (and ultra's) plugin since I suspect this is provider-specific behavior and since there's NS1 specific logic I had to tweak, so I wanted to keep everything in once place.

## Test Plan
- Updated one of the existing unit tests
- Manually tested the failing case with this change (in conjunction with an equivalent change to `octodns-ultra`)